### PR TITLE
Corrected bug: PHP AJAX messages in multilanguage [2]

### DIFF
--- a/elements/yjsgupdate.php
+++ b/elements/yjsgupdate.php
@@ -30,6 +30,8 @@ $session 				= JFactory::getSession();
 $user 					= JFactory::getUser();
 $compile_link			= preg_replace('/(\btemplates\b|\bmodules\b|\bcomponents\b|\bplugins\b)(.*)/','',JURI::root());
 $siteBase				= $compile_link;
+$language				= JFactory::getLanguage();
+$language->setLanguage(JComponentHelper::getParams('com_languages')->get('site'));
 
 if(isset($_POST['task']))	{
 	


### PR DESCRIPTION
Needs to know the current language so it can show the messages in other languages, if not, only english.